### PR TITLE
fix(publish): update npm publish command to ignore scripts

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -68,6 +68,6 @@ jobs:
         run: |
           [ -n "$NPM_TOKEN" ] && npm config set //registry.npmjs.org/:_authToken "$NPM_TOKEN"
           pnpm run build
-          npm publish --provenance --access public
+          npm publish --provenance --access public --ignore-scripts
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
- Modified the npm publish command in the GitHub Actions workflow to include the --ignore-scripts flag, preventing the execution of scripts during the publishing process.